### PR TITLE
Achieve perfect Lighthouse scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # Vertical Latency
 
-Personal portfolio site for Keith Ort — a single-page, retro-neon throwback built with [Astro](https://astro.build). Zero JavaScript shipped except the WCAG motion-pause toggle.
+Personal portfolio site for Keith Ort — a Geocities throwback built with [Astro](https://astro.build).
 
 ## Stack
 
 - **Astro 6** — static output, single page
 - **Vanilla CSS** — neon theme (cyan/magenta/yellow/lime on deep navy), Monoton + VT323 fonts, starfield background
 - **Tailwind CSS v4** — available via Vite plugin (design is hand-rolled CSS)
-
-## Sections
-
-Hero with animated logo and CSS marquee · About Me · Useless Information (hobbies, favorites, video games) · Work History timeline · Contact · footer with obligatory LED hit counter and Netscape badge.
 
 ## Development
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,33 @@
 // @ts-check
-import { defineConfig } from 'astro/config';
+import { defineConfig, fontProviders } from 'astro/config';
 
 import tailwindcss from '@tailwindcss/vite';
 
 // https://astro.build/config
 export default defineConfig({
+  build: {
+    inlineStylesheets: 'always'
+  },
+  fonts: [
+    {
+      provider: fontProviders.google(),
+      name: 'Monoton',
+      cssVariable: '--font-monoton',
+      weights: [400],
+      styles: ['normal'],
+      subsets: ['latin'],
+      fallbacks: ['cursive']
+    },
+    {
+      provider: fontProviders.google(),
+      name: 'VT323',
+      cssVariable: '--font-vt323',
+      weights: [400],
+      styles: ['normal'],
+      subsets: ['latin'],
+      fallbacks: ['monospace']
+    }
+  ],
   vite: {
     plugins: [tailwindcss()]
   }

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -68,7 +68,7 @@ const links = [
     margin-top: 6px;
   }
   .contact-links a {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 20px;
     text-decoration: none;
     display: inline-flex;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -40,7 +40,7 @@ const digits = ['0', '0', '4', '2', '8', '9', '1'];
     box-shadow: inset 0 0 8px #000;
   }
   .leds b {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-weight: normal;
     font-size: 24px;
     line-height: 1;
@@ -51,13 +51,13 @@ const digits = ['0', '0', '4', '2', '8', '9', '1'];
     text-shadow: 0 0 8px rgba(255,90,77,.9);
   }
   .counter small {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 15px;
     color: var(--color-ink2);
     letter-spacing: 1px;
   }
   .badge {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 15px;
     color: var(--color-ink2);
     border: 1px solid var(--color-hr);
@@ -68,7 +68,7 @@ const digits = ['0', '0', '4', '2', '8', '9', '1'];
     background: rgba(0,0,0,.25);
   }
   .copyright {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 15px;
     color: var(--color-ink2);
     text-align: right;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -20,7 +20,7 @@ const navItems = [
 <style>
   .hero { text-align: center; padding-top: 34px; }
   .logo {
-    font-family: "Monoton", cursive;
+    font-family: var(--font-monoton);
     font-size: clamp(40px, 8.5vw, 86px);
     line-height: 1;
     letter-spacing: 1px;
@@ -46,7 +46,7 @@ const navItems = [
     font-size: .62em;
   }
   .tagline {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: clamp(16px, 2.4vw, 24px);
     color: var(--color-neon2);
     text-shadow: 0 0 8px rgba(255,54,208,.7);
@@ -55,7 +55,7 @@ const navItems = [
     margin: 14px 0 0;
   }
   .since {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     color: var(--color-ink2);
     font-size: 18px;
     letter-spacing: 1px;
@@ -69,7 +69,7 @@ const navItems = [
     margin-top: 22px;
   }
   nav.main a {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 21px;
     letter-spacing: 1px;
     text-decoration: none;

--- a/src/components/Marquee.astro
+++ b/src/components/Marquee.astro
@@ -27,7 +27,7 @@
     animation: scrollx 22s linear infinite;
   }
   .marquee .track span {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 21px;
     letter-spacing: 1px;
     color: var(--color-neon4);

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -158,7 +158,7 @@ const condensedRoles = [
     display: inline-flex;
     align-items: center;
     gap: 9px;
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 19px;
     color: var(--color-neon3);
     letter-spacing: 1px;
@@ -221,7 +221,7 @@ const condensedRoles = [
   .card .ctop { display: block; margin-bottom: 7px; }
   .card .co {
     display: block;
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 25px;
     letter-spacing: .5px;
     color: var(--color-neon1);
@@ -234,7 +234,7 @@ const condensedRoles = [
   }
   .card .dt {
     display: block;
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 15px;
     color: var(--color-ink2);
     margin-top: 2px;
@@ -260,7 +260,7 @@ const condensedRoles = [
 
   /* Condensed older roles */
   .cond-h {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 20px;
     color: var(--color-ink2);
     letter-spacing: 1px;
@@ -283,7 +283,7 @@ const condensedRoles = [
     padding: 7px 2px;
   }
   .cond .row b {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 20px;
     color: var(--color-neon3);
     font-weight: normal;

--- a/src/components/UselessInfo.astro
+++ b/src/components/UselessInfo.astro
@@ -130,7 +130,7 @@ const games = [
   }
   .group + .group { margin-top: 24px; }
   .sub-h {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-weight: normal;
     font-size: 24px;
     letter-spacing: 1px;
@@ -155,7 +155,7 @@ const games = [
     margin-top: 8px;
   }
   .chip {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 18px;
     letter-spacing: .5px;
     border: 2px solid var(--color-neon2);
@@ -186,7 +186,7 @@ const games = [
     padding: 6px 2px;
   }
   .facts .row b {
-    font-family: "VT323", monospace;
+    font-family: var(--font-vt323);
     font-size: 19px;
     color: var(--color-neon3);
     font-weight: normal;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import { Font } from 'astro:assets';
 import '../styles/global.css';
 
 interface Props {
@@ -24,9 +25,8 @@ const { title = 'Vertical Latency :: Keith Ort, Web Developer', description = 'M
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#16f0e0" />
     <meta name="msapplication-TileColor" content="#070617" />
     <meta name="theme-color" content="#070617" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Monoton&family=VT323&display=swap" rel="stylesheet" />
+    <Font cssVariable="--font-monoton" preload />
+    <Font cssVariable="--font-vt323" preload />
     <title>{title}</title>
   </head>
   <body data-font="neon" data-motion="max">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,14 +13,16 @@ import Footer from '../components/Footer.astro';
 <Layout>
   <div class="page">
     <Header />
-    <Marquee />
-    <AboutMe />
-    <FlameDivider />
-    <UselessInfo />
-    <FlameDivider />
-    <Timeline />
-    <FlameDivider />
-    <Contact />
+    <main>
+      <Marquee />
+      <AboutMe />
+      <FlameDivider />
+      <UselessInfo />
+      <FlameDivider />
+      <Timeline />
+      <FlameDivider />
+      <Contact />
+    </main>
     <Footer />
   </div>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,8 +13,7 @@
   --color-ink2: #a7a3d6;
   --color-hr: #2b2566;
 
-  --font-monoton: "Monoton", cursive;
-  --font-vt323: "VT323", monospace;
+  /* --font-monoton and --font-vt323 are injected by Astro's <Font> component */
   --font-body: "Trebuchet MS", "Verdana", sans-serif;
 }
 
@@ -116,7 +115,7 @@ body.motion-paused .marquee .track { padding-left: 0 !important; }
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-family: "VT323", monospace;
+  font-family: var(--font-vt323);
   font-size: 17px;
   letter-spacing: .5px;
   color: var(--color-ink);


### PR DESCRIPTION
## Summary
- Self-host Monoton and VT323 via Astro 6's Fonts API, replacing the render-blocking Google Fonts stylesheet chain (~1.7s estimated savings on mobile). Both fonts are preloaded, and components now use the injected `--font-monoton`/`--font-vt323` CSS variables with metric-optimized fallbacks.
- Inline all stylesheets (`build.inlineStylesheets: 'always'`) so first paint requires zero render-blocking requests.
- Wrap page content in a `<main>` landmark, fixing the one failing accessibility audit.
- Tighten README description.

## Results (local Lighthouse, mobile emulation)
| | Before | After |
|---|---|---|
| Performance | 88 | **100** |
| Accessibility | 98 | **100** |
| Best Practices | 100 | **100** |
| SEO | 100 | **100** |
| FCP | 2.7s | 0.7s |
| LCP | 2.7s | 1.1s |
| Speed Index | 5.4s | 0.7s |

## Test plan
- [x] `npm run build` succeeds; dist has no fonts.googleapis/gstatic references, no external stylesheets, fonts preloaded from `/_astro/fonts/`
- [x] Lighthouse against local preview: 100/100/100/100
- [x] Visual check: Monoton logo and VT323 text render correctly with hashed font families
- [ ] Re-run PageSpeed Insights against production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)